### PR TITLE
Fix/ignore own events

### DIFF
--- a/hippo-backend/lib/graphql/events.ex
+++ b/hippo-backend/lib/graphql/events.ex
@@ -18,50 +18,50 @@ end
 
 defmodule Hippo.GraphQL.Events.Project do
   defmodule Created do
-    defstruct [:project]
+    defstruct [:session_token, :project]
   end
 
   defmodule Updated do
-    defstruct [:project]
+    defstruct [:session_token, :project]
   end
 
   defmodule Deleted do
-    defstruct [:project_id]
+    defstruct [:session_token, :project_id]
   end
 end
 
 defmodule Hippo.GraphQL.Events.Lane do
   defmodule Created do
-    defstruct [:lane]
+    defstruct [:session_token, :lane]
   end
 
   defmodule Updated do
-    defstruct [:lane]
+    defstruct [:session_token, :lane]
   end
 
   defmodule Deleted do
-    defstruct [:lane_id]
+    defstruct [:session_token, :lane_id]
   end
 
   defmodule Repositioned do
-    defstruct [:lane_id, :position]
+    defstruct [:session_token, :lane_id, :position]
   end
 end
 
 defmodule Hippo.GraphQL.Events.Card do
   defmodule Created do
-    defstruct [:card, :lane_id]
+    defstruct [:session_token, :card, :lane_id]
   end
 
   defmodule Updated do
-    defstruct [:card]
+    defstruct [:session_token, :card]
   end
 
   defmodule Deleted do
-    defstruct [:card_id, :lane_id]
+    defstruct [:session_token, :card_id, :lane_id]
   end
 
   defmodule Repositioned do
-    defstruct [:card_id, :source_lane_id, :target_lane_id, :position]
+    defstruct [:session_token, :card_id, :source_lane_id, :target_lane_id, :position]
   end
 end

--- a/hippo-backend/lib/graphql/resolvers/lane_resolver.ex
+++ b/hippo-backend/lib/graphql/resolvers/lane_resolver.ex
@@ -1,5 +1,5 @@
 defmodule Hippo.GraphQL.Resolvers.Lane do
-  alias Hippo.Lanes
+  alias Hippo.{Lanes, Session}
   alias Hippo.Lanes.Lane
   alias Hippo.GraphQL.Events
 
@@ -7,7 +7,7 @@ defmodule Hippo.GraphQL.Resolvers.Lane do
     with {:ok, lane} <- Lanes.create_lane(params, for_project: project_id),
          :ok <-
            publish(project_id, %Events.Lane.Created{
-             session_token: session_from_context(ctx),
+             session_token: Session.from_absinthe_context(ctx),
              lane: lane
            }) do
       {:ok, lane: lane}
@@ -20,7 +20,7 @@ defmodule Hippo.GraphQL.Resolvers.Lane do
          project_id <- Lanes.owning_project_id(lane),
          :ok <-
            publish(project_id, %Events.Lane.Updated{
-             session_token: session_from_context(ctx),
+             session_token: Session.from_absinthe_context(ctx),
              lane: lane
            }) do
       {:ok, lane: lane}
@@ -35,7 +35,7 @@ defmodule Hippo.GraphQL.Resolvers.Lane do
          {:ok, _} <- Lanes.delete_with_contents(lane_id),
          :ok <-
            publish(project_id, %Events.Lane.Deleted{
-             session_token: session_from_context(ctx),
+             session_token: Session.from_absinthe_context(ctx),
              lane_id: lane_id
            }) do
       {:ok, message: "lane and its card deleted"}
@@ -48,7 +48,7 @@ defmodule Hippo.GraphQL.Resolvers.Lane do
          project_id <- Lanes.owning_project_id(lane_id),
          :ok <-
            publish(project_id, %Events.Lane.Repositioned{
-             session_token: session_from_context(ctx),
+             session_token: Session.from_absinthe_context(ctx),
              lane_id: lane_id,
              position: position
            }) do
@@ -62,6 +62,4 @@ defmodule Hippo.GraphQL.Resolvers.Lane do
   defp publish(project_id, event) when is_binary(project_id) do
     Events.publish(:project_updates, "projects:#{project_id}", %{event: event})
   end
-
-  defp session_from_context(%{context: %{session_token: token}}), do: token
 end

--- a/hippo-backend/lib/graphql/resolvers/lane_resolver.ex
+++ b/hippo-backend/lib/graphql/resolvers/lane_resolver.ex
@@ -3,18 +3,26 @@ defmodule Hippo.GraphQL.Resolvers.Lane do
   alias Hippo.Lanes.Lane
   alias Hippo.GraphQL.Events
 
-  def create(%{lane: params, project_id: project_id}, _) do
+  def create(%{lane: params, project_id: project_id}, ctx) do
     with {:ok, lane} <- Lanes.create_lane(params, for_project: project_id),
-         :ok <- publish(project_id, %Events.Lane.Created{lane: lane}) do
+         :ok <-
+           publish(project_id, %Events.Lane.Created{
+             session_token: session_from_context(ctx),
+             lane: lane
+           }) do
       {:ok, lane: lane}
     end
   end
 
-  def update(%{lane_id: lane_id, lane: params}, _) do
+  def update(%{lane_id: lane_id, lane: params}, ctx) do
     with {:lane, %Lane{} = lane} <- {:lane, Lanes.get_lane(lane_id)},
          {:ok, lane} <- Lanes.update_lane(lane, params),
          project_id <- Lanes.owning_project_id(lane),
-         :ok <- publish(project_id, %Events.Lane.Updated{lane: lane}) do
+         :ok <-
+           publish(project_id, %Events.Lane.Updated{
+             session_token: session_from_context(ctx),
+             lane: lane
+           }) do
       {:ok, lane: lane}
     else
       {:error, _} = error -> error
@@ -22,20 +30,25 @@ defmodule Hippo.GraphQL.Resolvers.Lane do
     end
   end
 
-  def delete(%{lane_id: lane_id}, _ctx) do
+  def delete(%{lane_id: lane_id}, ctx) do
     with project_id <- Lanes.owning_project_id(lane_id),
          {:ok, _} <- Lanes.delete_with_contents(lane_id),
-         :ok <- publish(project_id, %Events.Lane.Deleted{lane_id: lane_id}) do
+         :ok <-
+           publish(project_id, %Events.Lane.Deleted{
+             session_token: session_from_context(ctx),
+             lane_id: lane_id
+           }) do
       {:ok, message: "lane and its card deleted"}
     end
   end
 
-  def reposition(%{lane_id: lane_id, position: position}, _ctx) do
+  def reposition(%{lane_id: lane_id, position: position}, ctx) do
     with {:lane, %Lane{} = lane} <- {:lane, Lanes.get_lane(lane_id)},
          {:ok, lane} <- Lanes.update_lane(lane, %{position: position}),
          project_id <- Lanes.owning_project_id(lane_id),
          :ok <-
            publish(project_id, %Events.Lane.Repositioned{
+             session_token: session_from_context(ctx),
              lane_id: lane_id,
              position: position
            }) do
@@ -47,6 +60,8 @@ defmodule Hippo.GraphQL.Resolvers.Lane do
   end
 
   defp publish(project_id, event) when is_binary(project_id) do
-    Events.publish(:project_updates, "projects:#{project_id}", event)
+    Events.publish(:project_updates, "projects:#{project_id}", %{event: event})
   end
+
+  defp session_from_context(%{context: %{session_token: token}}), do: token
 end

--- a/hippo-backend/lib/graphql/resolvers/project_resolver.ex
+++ b/hippo-backend/lib/graphql/resolvers/project_resolver.ex
@@ -1,5 +1,5 @@
 defmodule Hippo.GraphQL.Resolvers.Project do
-  alias Hippo.Projects
+  alias Hippo.{Projects, Session}
   alias Hippo.GraphQL.Events
 
   @doc "Resolve by returning a single project by ID"
@@ -19,7 +19,7 @@ defmodule Hippo.GraphQL.Resolvers.Project do
     with {:ok, project} <- Projects.create_project(params),
          :ok <-
            publish(%Events.Project.Created{
-             session_token: session_from_context(ctx),
+             session_token: Session.from_absinthe_context(ctx),
              project: project
            }) do
       {:ok, project: project}
@@ -35,7 +35,7 @@ defmodule Hippo.GraphQL.Resolvers.Project do
            {:updated, Projects.update_project(project, params)},
          :ok <-
            publish(%Events.Project.Updated{
-             session_token: session_from_context(ctx),
+             session_token: Session.from_absinthe_context(ctx),
              project: project
            }) do
       {:ok, project: project}
@@ -49,7 +49,7 @@ defmodule Hippo.GraphQL.Resolvers.Project do
     with {:ok, response} <- Projects.delete_with_contents(project_id),
          :ok <-
            publish(%Events.Project.Deleted{
-             session_token: session_from_context(ctx),
+             session_token: Session.from_absinthe_context(ctx),
              project_id: project_id
            }) do
       {:ok, response}
@@ -61,6 +61,4 @@ defmodule Hippo.GraphQL.Resolvers.Project do
   defp publish(event) do
     Events.publish(:projects_updates, "projects:all", %{payload: event})
   end
-
-  defp session_from_context(%{context: %{session_token: token}}), do: token
 end

--- a/hippo-backend/lib/graphql/session_plug.ex
+++ b/hippo-backend/lib/graphql/session_plug.ex
@@ -1,0 +1,14 @@
+defmodule Hippo.GraphQL.SessionPlug do
+  @behaviour Plug
+
+  def init(opts), do: opts
+
+  def call(conn, _) do
+    session_token =
+      conn
+      |> Plug.Conn.get_req_header("x-session-token")
+      |> List.first()
+
+    Absinthe.Plug.put_options(conn, context: %{session_token: session_token})
+  end
+end

--- a/hippo-backend/lib/graphql/types/event_types.ex
+++ b/hippo-backend/lib/graphql/types/event_types.ex
@@ -14,7 +14,7 @@ defmodule Hippo.GraphQL.Types.Event do
     field(:project_id, :identifier)
   end
 
-  union :projects_event do
+  union :projects_event_payload do
     @desc "Events for higher level events that concern projects. Eg; Project created, removed or updated."
     types([:project_created_event, :project_updated_event, :project_deleted_event])
 
@@ -23,6 +23,20 @@ defmodule Hippo.GraphQL.Types.Event do
       %Events.Project.Created{}, _ -> :project_created_event
       %Events.Project.Deleted{}, _ -> :project_deleted_event
     end)
+  end
+
+  object :projects_event do
+    field(:triggered_by_self, :boolean,
+      description: "Wether or not the event was triggered by the user that received the event",
+      resolve: fn %{payload: %{session_token: trigger_session}},
+                  _,
+                  %{context: %{session: current_session}} ->
+        {:ok, trigger_session == current_session}
+      end
+    )
+
+    @desc "The actual details of the given event"
+    field(:payload, :projects_event_payload)
   end
 
   object :lane_created_event do
@@ -63,9 +77,7 @@ defmodule Hippo.GraphQL.Types.Event do
     field(:position, :integer)
   end
 
-  union :project_events do
-    @desc "Events for a given projects. Eg; updates to lanes or cards within a project"
-
+  union :project_events_payload do
     types([
       :lane_created_event,
       :lane_updated_event,
@@ -87,5 +99,20 @@ defmodule Hippo.GraphQL.Types.Event do
       %Events.Card.Deleted{}, _ -> :card_deleted_event
       %Events.Card.Repositioned{}, _ -> :card_repositioned_event
     end)
+  end
+
+  @desc "Events for a given projects. Eg; updates to lanes or cards within a project"
+  object :project_events do
+    field(:triggered_by_self, :boolean,
+      description: "Wether or not the event was triggered by the user that received the event",
+      resolve: fn %{payload: %{session_token: trigger_session}},
+                  _,
+                  %{context: %{session: current_session}} ->
+        {:ok, trigger_session == current_session}
+      end
+    )
+
+    @desc "The actual details of the given event"
+    field(:payload, :project_events_payload)
   end
 end

--- a/hippo-backend/lib/graphql/types/event_types.ex
+++ b/hippo-backend/lib/graphql/types/event_types.ex
@@ -28,11 +28,7 @@ defmodule Hippo.GraphQL.Types.Event do
   object :projects_event do
     field(:triggered_by_self, :boolean,
       description: "Wether or not the event was triggered by the user that received the event",
-      resolve: fn %{payload: %{session_token: trigger_session}},
-                  _,
-                  %{context: %{session: current_session}} ->
-        {:ok, trigger_session == current_session}
-      end
+      resolve: &session_matches?/3
     )
 
     @desc "The actual details of the given event"
@@ -105,14 +101,17 @@ defmodule Hippo.GraphQL.Types.Event do
   object :project_events do
     field(:triggered_by_self, :boolean,
       description: "Wether or not the event was triggered by the user that received the event",
-      resolve: fn %{payload: %{session_token: trigger_session}},
-                  _,
-                  %{context: %{session: current_session}} ->
-        {:ok, trigger_session == current_session}
-      end
+      resolve: &session_matches?/3
     )
 
     @desc "The actual details of the given event"
     field(:payload, :project_events_payload)
   end
+
+  defp session_matches?(
+         %{payload: %{session_token: trigger_session}},
+         _,
+         %{context: %{session: current_session}}
+       ),
+       do: {:ok, trigger_session == current_session}
 end

--- a/hippo-backend/lib/hippo/session.ex
+++ b/hippo-backend/lib/hippo/session.ex
@@ -1,0 +1,3 @@
+defmodule Hippo.Session do
+  def from_absinthe_context(%{context: %{session_token: token}}), do: token
+end

--- a/hippo-backend/lib/hippo_web/channels/user_socket.ex
+++ b/hippo-backend/lib/hippo_web/channels/user_socket.ex
@@ -18,7 +18,9 @@ defmodule HippoWeb.UserSocket do
   #
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
-  def connect(_params, socket, _connect_info) do
+  def connect(params, socket, connect_info) do
+    session_token = Map.get(params, "sessionToken")
+    socket = Absinthe.Phoenix.Socket.put_options(socket, context: %{session: session_token})
     {:ok, socket}
   end
 

--- a/hippo-backend/lib/hippo_web/router.ex
+++ b/hippo-backend/lib/hippo_web/router.ex
@@ -2,24 +2,29 @@ defmodule HippoWeb.Router do
   use HippoWeb, :router
 
   pipeline :api do
-    plug :accepts, ["json"]
+    plug(:accepts, ["json"])
 
-    plug Plug.Parsers,
+    plug(Hippo.GraphQL.SessionPlug)
+
+    plug(Plug.Parsers,
       parsers: [:urlencoded, :multipart, :json],
       json_decoder: Jason
+    )
   end
 
   scope "/" do
-    pipe_through :api
+    pipe_through(:api)
 
-    forward "/graphql", Absinthe.Plug,
+    forward("/graphql", Absinthe.Plug,
       schema: Hippo.GraphQL.Schema,
       json_codec: Jason
+    )
 
-    forward "/graphiql", Absinthe.Plug.GraphiQL,
+    forward("/graphiql", Absinthe.Plug.GraphiQL,
       schema: Hippo.GraphQL.Schema,
       interface: :playground,
       json_codec: Jason,
       socket_url: "ws://localhost:4000/socket"
+    )
   end
 end

--- a/hippo-frontend/src/graphql/client.js
+++ b/hippo-frontend/src/graphql/client.js
@@ -18,9 +18,21 @@ import introspectionQueryResultData from "graphql/fragmentTypes.json";
 const httpUri = "http://localhost:4000/graphql";
 const wsUri = "ws://localhost:4000/socket";
 
-const httpLink = new HttpLink({ uri: httpUri });
+const getSessionToken = () => "hah-lol-hope";
+
+const httpLink = new HttpLink({
+  uri: httpUri,
+  headers: { "x-session-token": getSessionToken() }
+});
+
 const wsLink = createAbsintheSocketLink(
-  AbsintheSocket.create(new PhoenixSocket(wsUri))
+  AbsintheSocket.create(
+    new PhoenixSocket(wsUri, {
+      params: {
+        sessionToken: getSessionToken()
+      }
+    })
+  )
 );
 
 // using the ability to split links, you can send data to each link

--- a/hippo-frontend/src/graphql/client.js
+++ b/hippo-frontend/src/graphql/client.js
@@ -18,7 +18,20 @@ import introspectionQueryResultData from "graphql/fragmentTypes.json";
 const httpUri = "http://localhost:4000/graphql";
 const wsUri = "ws://localhost:4000/socket";
 
-const getSessionToken = () => "hah-lol-hope";
+const getSessionToken = () => {
+  const sessionToken = window.sessionStorage.getItem("sessionToken");
+  if (sessionToken) return sessionToken;
+
+  const randomChars = Array.from(
+    window.crypto.getRandomValues(new Uint8Array(64))
+  )
+    .map(String.fromCharCode)
+    .join("");
+
+  const token = btoa(randomChars);
+  window.sessionStorage.setItem("sessionToken", token);
+  return token;
+};
 
 const httpLink = new HttpLink({
   uri: httpUri,

--- a/hippo-frontend/src/graphql/helpers/card_cache.js
+++ b/hippo-frontend/src/graphql/helpers/card_cache.js
@@ -16,13 +16,6 @@ const persistUpdatedLane = (client, lane) =>
 const createCard = (client, laneId, card) => {
   const { lane } = getLane(client, laneId);
 
-  // early return if card was already in cache. This can happen when the real-time event
-  // is delivered but we made the edit ourselves. This is a special case since we're not
-  // relying on Apollo to refetch the query.
-  if (lane.cards.find(existingCard => existingCard.id === card.id) !== null) {
-    return;
-  }
-
   const updatedLane = {
     ...lane,
     cards: [card, ...lane.cards]

--- a/hippo-frontend/src/graphql/hooks/project_subscription_hook.js
+++ b/hippo-frontend/src/graphql/hooks/project_subscription_hook.js
@@ -4,34 +4,44 @@ import LaneCache from "graphql/helpers/lane_cache";
 import CardCache from "graphql/helpers/card_cache";
 
 const handleEvent = (client, projectId, event) => {
-  switch (event.__typename) {
+  // If the event was triggered by ourselves, drop the event since we do not want to replay the
+  // same event twice.
+  if (event.triggeredBySelf) return;
+
+  const payload = event.payload;
+  switch (payload.__typename) {
     case "LaneCreatedEvent":
-      LaneCache.createLane(client, projectId, event.lane);
+      LaneCache.createLane(client, projectId, payload.lane);
       break;
 
     case "LaneDeletedEvent":
-      LaneCache.deleteLane(client, projectId, event.laneId);
+      LaneCache.deleteLane(client, projectId, payload.laneId);
       break;
 
     case "LaneRepositionedEvent":
-      LaneCache.repositionLane(client, projectId, event.laneId, event.position);
+      LaneCache.repositionLane(
+        client,
+        projectId,
+        payload.laneId,
+        payload.position
+      );
       break;
 
     case "CardCreatedEvent":
-      CardCache.createCard(client, event.laneId, event.card);
+      CardCache.createCard(client, payload.laneId, payload.card);
       break;
 
     case "CardDeletedEvent":
-      CardCache.deleteCard(client, event.laneId, event.cardId);
+      CardCache.deleteCard(client, payload.laneId, payload.cardId);
       break;
 
     case "CardRepositionedEvent":
       CardCache.repositionCard(
         client,
-        event.cardId,
-        event.sourceLaneId,
-        event.targetLaneId,
-        event.position
+        payload.cardId,
+        payload.sourceLaneId,
+        payload.targetLaneId,
+        payload.position
       );
       break;
 

--- a/hippo-frontend/src/graphql/hooks/projects_all_subscription_hook.js
+++ b/hippo-frontend/src/graphql/hooks/projects_all_subscription_hook.js
@@ -3,18 +3,23 @@ import PROJECTS_ALL_SUBSCRIPTION from "graphql/projects_all_subscription";
 import ProjectCache from "graphql/helpers/project_cache";
 
 const handleEvent = (client, event) => {
-  switch (event.__typename) {
+  // If the event was triggered by ourselves, drop the event since we do not want to replay the
+  // same event twice.
+  if (event.triggeredBySelf) return;
+
+  const payload = event.payload;
+  switch (payload.__typename) {
     case "ProjectUpdatedEvent":
       // No explicit action required, Apollo will update the project
       // since it has matching IDs in the payload.
       break;
 
     case "ProjectDeletedEvent":
-      ProjectCache.deleteProject(client, event.projectId);
+      ProjectCache.deleteProject(client, payload.projectId);
       break;
 
     case "ProjectCreatedEvent":
-      ProjectCache.createProject(client, event.project);
+      ProjectCache.createProject(client, payload.project);
       break;
 
     default:

--- a/hippo-frontend/src/graphql/project_subscription.js
+++ b/hippo-frontend/src/graphql/project_subscription.js
@@ -2,65 +2,68 @@ import gql from "graphql-tag";
 export default gql`
   subscription ProjectUpdates($projectId: identifier!) {
     projectUpdates(projectId: $projectId) {
-      __typename
+      triggeredBySelf
+      payload {
+        __typename
 
-      ... on LaneCreatedEvent {
-        lane {
-          id
-          title
-          description
-          cards {
+        ... on LaneCreatedEvent {
+          lane {
+            id
+            title
+            description
+            cards {
+              id
+              title
+              description
+            }
+          }
+        }
+
+        ... on LaneDeletedEvent {
+          laneId
+        }
+
+        ... on LaneUpdatedEvent {
+          lane {
             id
             title
             description
           }
         }
-      }
 
-      ... on LaneDeletedEvent {
-        laneId
-      }
-
-      ... on LaneUpdatedEvent {
-        lane {
-          id
-          title
-          description
+        ... on LaneRepositionedEvent {
+          laneId
+          position
         }
-      }
 
-      ... on LaneRepositionedEvent {
-        laneId
-        position
-      }
-
-      ... on CardCreatedEvent {
-        card {
-          id
-          title
-          description
+        ... on CardCreatedEvent {
+          card {
+            id
+            title
+            description
+          }
+          laneId
         }
-        laneId
-      }
 
-      ... on CardUpdatedEvent {
-        card {
-          id
-          title
-          description
+        ... on CardUpdatedEvent {
+          card {
+            id
+            title
+            description
+          }
         }
-      }
 
-      ... on CardDeletedEvent {
-        cardId
-        laneId
-      }
+        ... on CardDeletedEvent {
+          cardId
+          laneId
+        }
 
-      ... on CardRepositionedEvent {
-        cardId
-        sourceLaneId
-        targetLaneId
-        position
+        ... on CardRepositionedEvent {
+          cardId
+          sourceLaneId
+          targetLaneId
+          position
+        }
       }
     }
   }

--- a/hippo-frontend/src/graphql/projects_all_subscription.js
+++ b/hippo-frontend/src/graphql/projects_all_subscription.js
@@ -2,25 +2,28 @@ import gql from "graphql-tag";
 export default gql`
   subscription {
     projectsUpdates {
-      __typename
+      triggeredBySelf
+      payload {
+        __typename
 
-      ... on ProjectUpdatedEvent {
-        project {
-          id
-          title
-          description
+        ... on ProjectUpdatedEvent {
+          project {
+            id
+            title
+            description
+          }
         }
-      }
 
-      ... on ProjectDeletedEvent {
-        projectId
-      }
+        ... on ProjectDeletedEvent {
+          projectId
+        }
 
-      ... on ProjectCreatedEvent {
-        project {
-          id
-          title
-          description
+        ... on ProjectCreatedEvent {
+          project {
+            id
+            title
+            description
+          }
         }
       }
     }


### PR DESCRIPTION
Make sure we don't replay the events we triggered ourselves.
Tag every client with an unique session id and tag every event with the origin session id. If the two identifiers match, we can early return upon applying the event.

**Todo**
- [x] Refactor the code (make it DRY)